### PR TITLE
Match responses only to requests sent after subscribing

### DIFF
--- a/mqtt-client/src/commonMain/kotlin/de/kempmobil/ktor/mqtt/MqttClient.kt
+++ b/mqtt-client/src/commonMain/kotlin/de/kempmobil/ktor/mqtt/MqttClient.kt
@@ -126,11 +126,12 @@ public class MqttClient internal constructor(
 
     private val scope = CoroutineScope(config.dispatcher)
 
-    // A replay cache is crucial here to prevent a race condition where a response packet arrives
-    // before the corresponding `awaitResponseOf` call is able to subscribe to the flow. Without a
-    // replay cache, such a packet would be lost. A capacity of 16 is chosen to safely handle
-    // bursts of responses from concurrent requests.
-    private val receivedPackets = MutableSharedFlow<Packet>(replay = 16)
+    // Must not replay: a replayed packet lets a response that arrived before the request was even
+    // sent (e.g. an acknowledgement from a previous connection reusing the same packet identifier,
+    // or an old PINGRESP) be matched as the answer to a new request. The race between sending a
+    // request and subscribing to this flow is instead closed in awaitResponseOf(), which only
+    // sends the request once the subscription is established.
+    private val receivedPackets = MutableSharedFlow<Packet>()
 
     @OptIn(ExperimentalAtomicApi::class)
     private val packetIdentifier = AtomicInt(0)
@@ -626,9 +627,10 @@ public class MqttClient internal constructor(
         predicate: suspend (Packet) -> Boolean,
         request: suspend () -> Result<Unit>
     ): Result<P> {
+        val subscribed = CompletableDeferred<Unit>()
         val waitForResponse = scope.async {
             val response = withTimeoutOrNull(config.ackMessageTimeout) {
-                (receivedPackets.first(predicate) as P)
+                (receivedPackets.onSubscription { subscribed.complete(Unit) }.first(predicate) as P)
             }
             if (response != null) {
                 Result.success(response)
@@ -636,6 +638,13 @@ public class MqttClient internal constructor(
                 Result.failure(TimeoutException("Didn't receive requested packet within ${config.ackMessageTimeout}"))
             }
         }
+        waitForResponse.invokeOnCompletion { cause ->
+            if (cause != null) subscribed.completeExceptionally(cause)
+        }
+
+        // Only send the request once the response subscription is established, otherwise the response might
+        // arrive before the subscription and would then be lost.
+        subscribed.await()
         request().onFailure {
             waitForResponse.cancel()
             return Result.failure(it)

--- a/mqtt-client/src/commonTest/kotlin/de/kempmobil/ktor/mqtt/MqttClientTest.kt
+++ b/mqtt-client/src/commonTest/kotlin/de/kempmobil/ktor/mqtt/MqttClientTest.kt
@@ -8,13 +8,11 @@ import dev.mokkery.answering.returns
 import dev.mokkery.matcher.any
 import dev.mokkery.matcher.ofType
 import dev.mokkery.verify.VerifyMode
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.io.bytestring.encodeToByteString
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 import kotlin.time.Clock
@@ -107,21 +105,21 @@ class MqttClientTest {
 
     @Test
     fun `connect succeeds when receiving successful connack packet`() = runTest {
-        everySuspend { engine.start() } returns Result.success(Unit)
-        everySuspend { engine.send(ofType<Connect>()) } returns Result.success(Unit)
-
         val connack = Connack(
             isSessionPresent = false,
             reason = Success,
             topicAliasMaximum = TopicAliasMaximum(42u),
             maximumQoS = MaximumQoS(1)
         )
+        everySuspend { engine.start() } returns Result.success(Unit)
+        everySuspend { engine.send(ofType<Connect>()) } calls {
+            packetResults.emit(Result.success(connack))
+            Result.success(Unit)
+        }
         connectionState.emit(true)
 
         val client = createClient(engine)
-        val result = sendPacket(connack) {
-            client.connect()
-        }
+        val result = client.connect()
 
         assertTrue(result.isSuccess)
         assertEquals(connack, result.getOrNull())
@@ -147,20 +145,20 @@ class MqttClientTest {
     @Test
     fun `assigned client ID overrides the local client ID if empty`() = runTest {
         // See also MQTT-3.2.2-16
-        everySuspend { engine.start() } returns Result.success(Unit)
-        everySuspend { engine.send(ofType<Connect>()) } returns Result.success(Unit)
-
         val connack = Connack(
             isSessionPresent = false,
             reason = Success,
             assignedClientIdentifier = AssignedClientIdentifier("server-client-id")
         )
+        everySuspend { engine.start() } returns Result.success(Unit)
+        everySuspend { engine.send(ofType<Connect>()) } calls {
+            packetResults.emit(Result.success(connack))
+            Result.success(Unit)
+        }
         connectionState.emit(true)
 
         val client = createClient(engine, "")
-        val result = sendPacket(connack) {
-            client.connect()
-        }
+        val result = client.connect()
 
         assertTrue(result.isSuccess)
         assertEquals("server-client-id", client.clientId)
@@ -168,22 +166,22 @@ class MqttClientTest {
 
     @Test
     fun `connect fails when receiving unsuccessful connack packet and client disconnects`() = runTest {
-        everySuspend { engine.start() } returns Result.success(Unit)
-        everySuspend { engine.send(ofType<Connect>()) } returns Result.success(Unit)
-        everySuspend { engine.disconnect() } returns Unit
-
         val connack = Connack(
             isSessionPresent = false,
             reason = NotAuthorized,
             topicAliasMaximum = TopicAliasMaximum(42u),
             maximumQoS = MaximumQoS(1)
         )
+        everySuspend { engine.start() } returns Result.success(Unit)
+        everySuspend { engine.send(ofType<Connect>()) } calls {
+            packetResults.emit(Result.success(connack))
+            Result.success(Unit)
+        }
+        everySuspend { engine.disconnect() } returns Unit
         connectionState.emit(true)
 
         val client = createClient(engine)
-        val result = sendPacket(connack) {
-            client.connect()
-        }
+        val result = client.connect()
 
         assertTrue(result.isSuccess)
 
@@ -221,20 +219,21 @@ class MqttClientTest {
 
     @Test
     fun `subscribe succeeds when receiving suback packet`() = runTest {
-        everySuspend { engine.send(ofType<Subscribe>()) } returns Result.success(Unit)
-
         val suback = Suback(
             packetIdentifier = 1u,
             reasons = listOf(GrantedQoS0, TopicFilterInvalid)
         )
+        everySuspend { engine.send(ofType<Subscribe>()) } calls {
+            packetResults.emit(Result.success(suback))
+            Result.success(Unit)
+        }
+
         val filters = buildFilterList {
             add("test/topic1")
             add("test/topic2")
         }
         val client = createClient(engine)
-        val result = sendPacket(suback) {
-            client.subscribe(filters)
-        }
+        val result = client.subscribe(filters)
 
         assertTrue(result.isSuccess)
         assertSame(suback, result.getOrNull())
@@ -288,17 +287,18 @@ class MqttClientTest {
 
     @Test
     fun `unsubscribe succeeds when receiving unsuback packet`() = runTest {
-        everySuspend { engine.send(ofType<Unsubscribe>()) } returns Result.success(Unit)
-
         val unsuback = Unsuback(
             packetIdentifier = 1u,
             reasons = listOf(GrantedQoS0, TopicFilterInvalid)
         )
+        everySuspend { engine.send(ofType<Unsubscribe>()) } calls {
+            packetResults.emit(Result.success(unsuback))
+            Result.success(Unit)
+        }
+
         val filters = listOf("test/topic".toTopic())
         val client = createClient(engine)
-        val result = sendPacket(unsuback) {
-            client.unsubscribe(filters)
-        }
+        val result = client.unsubscribe(filters)
 
         assertTrue(result.isSuccess)
         assertSame(unsuback, result.getOrNull())
@@ -367,8 +367,10 @@ class MqttClientTest {
         var inFlightPacket: InFlightPublish? = null
         val client = createClient(engine)
         connectionState.emit(true)
-        packetResults.emit(Result.success(Puback(1u, Success)))
-        everySuspend { engine.send(ofType<Publish>()) } returns Result.success(Unit)
+        everySuspend { engine.send(ofType<Publish>()) } calls {
+            packetResults.emit(Result.success(Puback(1u, Success)))
+            Result.success(Unit)
+        }
         every { session.store(any()) } calls { (publish: Publish) ->
             InFlightPublish(publish, Clock.System.now(), 1).also { inFlightPacket = it }
         }
@@ -391,10 +393,14 @@ class MqttClientTest {
         var inFlightPubrel: InFlightPubrel? = null
         val client = createClient(engine)
         connectionState.emit(true)
-        packetResults.emit(Result.success(Pubrec(1u, Success)))
-        packetResults.emit(Result.success(Pubcomp(1u, Success)))
-        everySuspend { engine.send(ofType<Publish>()) } returns Result.success(Unit)
-        everySuspend { engine.send(ofType<Pubrel>()) } returns Result.success(Unit)
+        everySuspend { engine.send(ofType<Publish>()) } calls {
+            packetResults.emit(Result.success(Pubrec(1u, Success)))
+            Result.success(Unit)
+        }
+        everySuspend { engine.send(ofType<Pubrel>()) } calls {
+            packetResults.emit(Result.success(Pubcomp(1u, Success)))
+            Result.success(Unit)
+        }
         every { session.store(any()) } calls { (publish: Publish) ->
             InFlightPublish(publish, Clock.System.now(), 1).also { inFlightPublish = it }
         }
@@ -444,10 +450,6 @@ class MqttClientTest {
 
     @Test
     fun `when the server does not support retained messages the retained flag is cleared`() = runTest {
-        everySuspend { engine.start() } returns Result.success(Unit)
-        everySuspend { engine.send(ofType<Connect>()) } returns Result.success(Unit)
-        everySuspend { engine.send(ofType<Publish>()) } returns Result.success(Unit)
-
         val connack = Connack(
             isSessionPresent = false,
             reason = Success,
@@ -455,12 +457,16 @@ class MqttClientTest {
             maximumQoS = MaximumQoS(1),
             retainAvailable = RetainAvailable(false)  // 1. Server says it doesn't support retain
         )
+        everySuspend { engine.start() } returns Result.success(Unit)
+        everySuspend { engine.send(ofType<Connect>()) } calls {
+            packetResults.emit(Result.success(connack))
+            Result.success(Unit)
+        }
+        everySuspend { engine.send(ofType<Publish>()) } returns Result.success(Unit)
         connectionState.emit(true)
 
         val client = createClient(engine)
-        val connect = sendPacket(connack) {
-            client.connect()
-        }
+        val connect = client.connect()
 
         assertTrue(connect.isSuccess)
 
@@ -520,19 +526,5 @@ class MqttClientTest {
             clientId = id ?: ""
         }
         return MqttClient(config, connection, session)
-    }
-
-    /**
-     * Executes the specified coroutine asynchronously and the sends the specified packet to the `packetResults` flow.
-     */
-    private suspend fun <T> TestScope.sendPacket(packet: Packet, block: suspend CoroutineScope.() -> T): T {
-        with(this) {
-            val response = async {
-                block()
-            }
-            testScheduler.advanceUntilIdle()
-            packetResults.emit(Result.success(packet))
-            return response.await()
-        }
     }
 }

--- a/mqtt-client/src/commonTest/kotlin/de/kempmobil/ktor/mqtt/MqttClientTest.kt
+++ b/mqtt-client/src/commonTest/kotlin/de/kempmobil/ktor/mqtt/MqttClientTest.kt
@@ -240,6 +240,26 @@ class MqttClientTest {
         assertSame(suback, result.getOrNull())
     }
 
+    @Test
+    fun `a response arriving before its request is sent is not matched as the answer`() = runTest {
+        everySuspend { engine.send(ofType<Subscribe>()) } returns Result.success(Unit)
+
+        val client = createClient(engine)
+        val marker = async { client.publishedPackets.first() }
+        testScheduler.advanceUntilIdle()
+
+        // A stale SUBACK arrives while no request is outstanding (e.g. an answer to a request from a previous
+        // connection). The first subscribe of this client will use the same packet identifier (1).
+        packetResults.emit(Result.success(Suback(packetIdentifier = 1u, reasons = listOf(GrantedQoS0))))
+        packetResults.emit(Result.success(Publish(topic = "marker".toTopic(), payload = "".encodeToByteString())))
+        marker.await() // Both stale packets have now been consumed by the client
+
+        val result = client.subscribe(buildFilterList { add("test/topic") })
+
+        assertTrue(result.isFailure, "A SUBACK the server sent before the SUBSCRIBE cannot be its answer")
+        assertIs<TimeoutException>(result.exceptionOrNull())
+    }
+
     // ---- UNSUBSCRIBE tests ------------------------------------------------------------------------------------------
 
     @Test


### PR DESCRIPTION
`receivedPackets` carried a 16 packet replay cache so that a response arriving between `engine.send()` and the waiter's subscription was not lost. The cache patched that race at the cost of a worse one: replayed packets satisfy *later* requests. Packet identifiers restart at 1 per client while acknowledgements are matched by identifier only, so an acknowledgement left over from a previous connection answers a new request whose identifier happens to collide — and the keep alive loop accepts a cached PINGRESP as proof of a live link, leaving a dead connection undetected forever.

This closes the original race directly instead: `awaitResponseOf()` only invokes the request callback once the response subscription is established (`onSubscription`), so no response can arrive unsubscribed and nothing needs to be replayed.

The QoS 1/2 publish and CONNACK/SUBACK/UNSUBACK tests previously emitted the response before or concurrently with the request and passed only because of the replay cache; they now emit the response from the `engine.send()` mock, which is also the order a real server answers in.

The first commit adds a failing test showing a stale response being matched to a fresh request; the second removes the replay cache and adds the subscribe-before-send guarantee.
