### PR TITLE
Fix two send quota leaks that stall publishing permanently

### DIFF
--- a/mqtt-client/src/commonMain/kotlin/de/kempmobil/ktor/mqtt/MqttClient.kt
+++ b/mqtt-client/src/commonMain/kotlin/de/kempmobil/ktor/mqtt/MqttClient.kt
@@ -65,8 +65,13 @@ public class MqttClient internal constructor(
         get() = _receiveMaximum
     private var _receiveMaximum = UShort.MAX_VALUE
         set(value) {
-            field = value
-            sendQuota = Semaphore(value.toInt())
+            // Replacing the semaphore strands publishers already suspended in acquire() on the old instance and
+            // forgets the permits held by in-flight messages, hence keep it when the value is unchanged (the
+            // common case when reconnecting to the same server).
+            if (field != value) {
+                field = value
+                sendQuota = Semaphore(value.toInt())
+            }
         }
 
     /**

--- a/mqtt-client/src/commonMain/kotlin/de/kempmobil/ktor/mqtt/MqttClient.kt
+++ b/mqtt-client/src/commonMain/kotlin/de/kempmobil/ktor/mqtt/MqttClient.kt
@@ -372,6 +372,7 @@ public class MqttClient internal constructor(
         val puback = awaitResponseOf<Puback>({ it.isResponseFor<Puback>(publish) }) {
             engine.send(publish)
         }.getOrElse {
+            releaseSendQuotaSafe() // No PUBACK will arrive to return the quota permit of this message
             it.throwHandshakeExceptionForTimeout("PUBACK", publish)
         }
 
@@ -386,6 +387,7 @@ public class MqttClient internal constructor(
         val pubrec = awaitResponseOf<Pubrec>({ it.isResponseFor<Pubrec>(publish) }) {
             engine.send(publish)
         }.getOrElse {
+            releaseSendQuotaSafe() // No PUBREC will arrive to return the quota permit of this message
             it.throwHandshakeExceptionForTimeout("PUBREC", publish)
         }
 
@@ -400,6 +402,7 @@ public class MqttClient internal constructor(
         val pubcomp = awaitResponseOf<Pubcomp>({ it.isResponseFor<Pubcomp>(pubrel.source) }) {
             engine.send(pubrel.source)
         }.getOrElse {
+            releaseSendQuotaSafe() // No PUBCOMP will arrive to return the quota permit of this message
             it.throwHandshakeExceptionForTimeout("PUBCOMP", publish)
         }
 

--- a/mqtt-client/src/commonTest/kotlin/de/kempmobil/ktor/mqtt/MqttClientTest.kt
+++ b/mqtt-client/src/commonTest/kotlin/de/kempmobil/ktor/mqtt/MqttClientTest.kt
@@ -423,6 +423,32 @@ class MqttClientTest {
     }
 
     @Test
+    fun `a publish that is never acknowledged returns its send quota permit`() = runTest(timeout = 5.seconds) {
+        val connack = Connack(isSessionPresent = false, reason = Success, receiveMaximum = ReceiveMaximum(1u))
+        everySuspend { engine.start() } returns Result.success(Unit)
+        everySuspend { engine.send(ofType<Connect>()) } calls {
+            packetResults.emit(Result.success(connack))
+            Result.success(Unit)
+        }
+        everySuspend { engine.send(ofType<Publish>()) } returns Result.success(Unit) // Never acknowledged
+        every { session.store(any()) } calls { (publish: Publish) ->
+            InFlightPublish(publish, Clock.System.now(), 1)
+        }
+        connectionState.emit(true)
+
+        val client = createClient(engine)
+        assertTrue(client.connect().isSuccess)
+
+        val first = client.publish(PublishRequest("test/topic") { desiredQoS = QoS.AT_LEAST_ONCE })
+        assertIs<HandshakeFailedException>(first.exceptionOrNull())
+
+        // With a receive maximum of 1, the timed out message above must have returned its quota permit,
+        // otherwise this second publish waits for the permit forever
+        val second = client.publish(PublishRequest("test/topic") { desiredQoS = QoS.AT_LEAST_ONCE })
+        assertIs<HandshakeFailedException>(second.exceptionOrNull())
+    }
+
+    @Test
     fun `when the server does not support retained messages the retained flag is cleared`() = runTest {
         everySuspend { engine.start() } returns Result.success(Unit)
         everySuspend { engine.send(ofType<Connect>()) } returns Result.success(Unit)

--- a/mqtt-client/src/commonTest/kotlin/de/kempmobil/ktor/mqtt/MqttClientTest.kt
+++ b/mqtt-client/src/commonTest/kotlin/de/kempmobil/ktor/mqtt/MqttClientTest.kt
@@ -9,7 +9,10 @@ import dev.mokkery.matcher.any
 import dev.mokkery.matcher.ofType
 import dev.mokkery.verify.VerifyMode
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import kotlinx.io.bytestring.encodeToByteString
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,6 +21,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 import kotlin.time.Clock
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
@@ -449,6 +453,42 @@ class MqttClientTest {
     }
 
     @Test
+    fun `a reconnect with an unchanged receive maximum keeps waiting publishers alive`() = runTest(timeout = 5.seconds) {
+        val connack = Connack(isSessionPresent = false, reason = Success, receiveMaximum = ReceiveMaximum(1u))
+        everySuspend { engine.start() } returns Result.success(Unit)
+        everySuspend { engine.send(ofType<Connect>()) } calls {
+            packetResults.emit(Result.success(connack))
+            Result.success(Unit)
+        }
+        everySuspend { engine.send(ofType<Publish>()) } returns Result.success(Unit) // Never acknowledged
+        every { session.store(any()) } calls { (publish: Publish) ->
+            InFlightPublish(publish, Clock.System.now(), 1)
+        }
+        connectionState.emit(true)
+
+        val client = createClient(engine, ackTimeout = 500.milliseconds)
+        assertTrue(client.connect().isSuccess)
+
+        // The first publish takes the only quota permit and waits for its PUBACK...
+        val holder = async(Dispatchers.Default) {
+            client.publish(PublishRequest("test/topic") { desiredQoS = QoS.AT_LEAST_ONCE })
+        }
+        withContext(Dispatchers.Default) { delay(100.milliseconds) }
+
+        // ...so the second publish suspends, waiting for the permit
+        val waiter = async(Dispatchers.Default) {
+            client.publish(PublishRequest("test/topic") { desiredQoS = QoS.AT_LEAST_ONCE })
+        }
+        withContext(Dispatchers.Default) { delay(100.milliseconds) }
+
+        // A reconnect must not strand the waiting publisher: once the first publish times out and returns
+        // its permit, the second one proceeds (and then times out in the same way)
+        assertTrue(client.connect().isSuccess)
+        assertIs<HandshakeFailedException>(holder.await().exceptionOrNull())
+        assertIs<HandshakeFailedException>(waiter.await().exceptionOrNull())
+    }
+
+    @Test
     fun `when the server does not support retained messages the retained flag is cleared`() = runTest {
         everySuspend { engine.start() } returns Result.success(Unit)
         everySuspend { engine.send(ofType<Connect>()) } returns Result.success(Unit)
@@ -519,10 +559,14 @@ class MqttClientTest {
         )
     }
 
-    private fun createClient(connection: MqttEngine, id: String? = null): MqttClient {
+    private fun createClient(
+        connection: MqttEngine,
+        id: String? = null,
+        ackTimeout: Duration = 100.milliseconds
+    ): MqttClient {
         val config = buildConfig(DefaultEngineFactory("", 0)) {
             connection { }
-            ackMessageTimeout = 100.milliseconds
+            ackMessageTimeout = ackTimeout
             clientId = id ?: ""
         }
         return MqttClient(config, connection, session)


### PR DESCRIPTION
Two send quota leaks (MQTT 5 §4.9), each with its own failing-test commit followed by its fix so the TDD can be replayed:

**A failed QoS handshake never returned its permit.** Publishing a QoS 1 or 2 message takes a permit from the send quota semaphore, which was only returned when the matching acknowledgement arrived. When it never arrives — ack timeout or a failed send — the permit leaked, so after Receive Maximum failed publishes every further publish suspended forever waiting for quota. The failure paths now release the permit; the double-release tolerance in `releaseSendQuotaSafe()` already covers the case where the acknowledgement still arrives late, after the timeout released it.

**Every CONNACK replaced the semaphore, even when the server's Receive Maximum was unchanged.** A publisher suspended in `acquire()` on the replaced instance waits on an object nothing releases anymore, so it hangs forever, and permits held by in-flight messages are forgotten. With the leak above fixed, the per-connection reset the replacement used to provide is no longer needed for balance, so the semaphore is now kept when the Receive Maximum is unchanged. A *changed* Receive Maximum still replaces it — carrying waiters over to a resized quota needs a bigger rework than a reconnect fix should be.
