### PR TITLE
Publish messages without an expiry unless one is requested

### DIFF
--- a/mqtt-client/src/commonMain/kotlin/de/kempmobil/ktor/mqtt/PublishRequest.kt
+++ b/mqtt-client/src/commonMain/kotlin/de/kempmobil/ktor/mqtt/PublishRequest.kt
@@ -5,7 +5,6 @@ import de.kempmobil.ktor.mqtt.util.toTopic
 import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.encodeToByteString
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.minutes
 
 public data class PublishRequest(
     val topic: Topic,
@@ -64,11 +63,12 @@ public class PublishRequestBuilder(
     public var isRetainMessage: Boolean = false
 
     /**
-     * Defines the lifetime of the Application Message. Using `null` means that the message expires when the session
-     * expires. The default value is 5 minutes, meaning that if a message of QoS 1 or 2 was not acknowledged within 5
-     * minutes, it will not be resented on session restart. For messages of QoS 0 this has no meaning.
+     * Defines the lifetime of the Application Message. When `null` (the default), no Message Expiry Interval is sent
+     * and the message does not expire [MQTT-3.3.2.3.3]. When set, the server drops the message once it has been
+     * queued for that long without being delivered, and this client will not resend it on session restart after it
+     * has expired.
      */
-    public var messageExpiryInterval: Duration? = 5.minutes
+    public var messageExpiryInterval: Duration? = null
 
     /**
      * Used as the Topic Name for a response message.

--- a/mqtt-client/src/commonTest/kotlin/de/kempmobil/ktor/mqtt/PublishRequestTest.kt
+++ b/mqtt-client/src/commonTest/kotlin/de/kempmobil/ktor/mqtt/PublishRequestTest.kt
@@ -2,8 +2,17 @@ package de.kempmobil.ktor.mqtt
 
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 
 class PublishRequestTest {
+
+    @Test
+    fun `a request without a message expiry interval creates a message that does not expire`() {
+        // [MQTT-3.3.2.3.3] "If absent, the Application Message does not expire"
+        val request = PublishRequest("test/topic") { }
+
+        assertNull(request.messageExpiryInterval)
+    }
 
     @Test
     fun `cannot create publish request with invalid topic name`() {


### PR DESCRIPTION
The publish builder defaulted `messageExpiryInterval` to 5 minutes, so every message carried an expiry the caller never asked for: messages queued at the broker for a disconnected persistent session were dropped after 5 minutes, and retained messages silently vanished from the topic. Per MQTT 5 §3.3.2.3.3 an absent Message Expiry Interval means the message does not expire — the KDoc also inverted the meaning of null (it read as "expires with the session"), which is corrected alongside.

The default is now `null`, i.e. no expiry unless the caller sets one. Callers who relied on the implicit 5 minutes can request it explicitly.

The first commit adds a failing test expecting a publish request that sets no expiry to carry no expiry property; the second removes the default.
