### PR TITLE
Set the DUP flag on publishes resent from the session store

### DIFF
--- a/mqtt-client/src/commonMain/kotlin/de/kempmobil/ktor/mqtt/MqttClient.kt
+++ b/mqtt-client/src/commonMain/kotlin/de/kempmobil/ktor/mqtt/MqttClient.kt
@@ -510,8 +510,8 @@ public class MqttClient internal constructor(
                     is InFlightPublish -> {
                         when (packet.source.qoS) {
                             QoS.AT_MOST_ONCE -> Logger.e { "Unexpected packet in session store: $packet" }
-                            QoS.AT_LEAST_ONCE -> sendAtLeastOnceMessage(packet)
-                            QoS.EXACTLY_ONE -> sendExactlyOnceMessage(packet)
+                            QoS.AT_LEAST_ONCE -> sendAtLeastOnceMessage(packet.asRedelivery())
+                            QoS.EXACTLY_ONE -> sendExactlyOnceMessage(packet.asRedelivery())
                         }
                     }
 
@@ -528,6 +528,14 @@ public class MqttClient internal constructor(
                 return
             }
         }
+    }
+
+    /**
+     * The DUP flag must be set when re-delivering a PUBLISH packet [MQTT-3.3.1-1]. Timestamp and key are kept, so
+     * the redelivery still matches its entry in the [SessionStore].
+     */
+    private fun InFlightPublish.asRedelivery(): InFlightPublish {
+        return InFlightPublish(source.copy(isDupMessage = true), timestamp, key)
     }
 
     private suspend fun handlePacketResult(result: Result<Packet>) {

--- a/mqtt-client/src/commonTest/kotlin/de/kempmobil/ktor/mqtt/MqttClientTest.kt
+++ b/mqtt-client/src/commonTest/kotlin/de/kempmobil/ktor/mqtt/MqttClientTest.kt
@@ -455,6 +455,37 @@ class MqttClientTest {
     }
 
     @Test
+    fun `resent publishes of a resumed session carry the DUP flag`() = runTest {
+        val original = Publish(
+            qoS = QoS.AT_LEAST_ONCE,
+            packetIdentifier = 1u,
+            topic = "test/topic".toTopic(),
+            payload = "resend me".encodeToByteString()
+        )
+        every { session.unacknowledgedPackets() } returns listOf(InFlightPublish(original, Clock.System.now(), 1))
+        every { session.acknowledge(any()) } returns Unit
+
+        var resent: Publish? = null
+        everySuspend { engine.start() } returns Result.success(Unit)
+        everySuspend { engine.send(ofType<Connect>()) } calls {
+            packetResults.emit(Result.success(Connack(isSessionPresent = true, reason = Success)))
+            Result.success(Unit)
+        }
+        everySuspend { engine.send(ofType<Publish>()) } calls { (publish: Publish) ->
+            resent = publish
+            packetResults.emit(Result.success(Puback(1u, Success)))
+            Result.success(Unit)
+        }
+        connectionState.emit(true)
+
+        val client = createClient(engine)
+        assertTrue(client.connect().isSuccess)
+
+        assertNotNull(resent, "The unacknowledged PUBLISH must be resent when the session is resumed")
+        assertTrue(resent.isDupMessage, "A re-delivered PUBLISH must have the DUP flag set [MQTT-3.3.1-1]")
+    }
+
+    @Test
     fun `a publish that is never acknowledged returns its send quota permit`() = runTest(timeout = 5.seconds) {
         val connack = Connack(isSessionPresent = false, reason = Success, receiveMaximum = ReceiveMaximum(1u))
         everySuspend { engine.start() } returns Result.success(Unit)


### PR DESCRIPTION
When a session is resumed, unacknowledged QoS 1 and 2 PUBLISH packets are re-delivered, and a re-delivery must carry the DUP flag [MQTT-3.3.1-1]. The resume path resent the stored packet verbatim with DUP still 0, so servers cannot distinguish the retransmission from a first attempt.

The resent packets are now marked as duplicates. Timestamp and sorting key of the in-flight packet are preserved, so the redelivery still matches its session store entry (the stores key on the packet identifier) and message expiry keeps counting from the original send.

The first commit adds a failing test expecting DUP on a resumed publish; the second makes it pass.
