### PR TITLE
Clear the incoming QoS 2 packet id memory with the session

### DIFF
--- a/mqtt-client/src/commonMain/kotlin/de/kempmobil/ktor/mqtt/MqttClient.kt
+++ b/mqtt-client/src/commonMain/kotlin/de/kempmobil/ktor/mqtt/MqttClient.kt
@@ -161,7 +161,7 @@ public class MqttClient internal constructor(
         connackFlow.emit(null)
 
         if (isCleanStart) {
-            session.clear()
+            clearSession()
         }
         return engine.start()
             .mapCatching {
@@ -175,7 +175,7 @@ public class MqttClient internal constructor(
                     if (connack.isSessionPresent) {
                         resumeSession()
                     } else {
-                        session.clear() // Probably redundant, just to be sure...
+                        clearSession() // Probably redundant when clean start was requested, just to be sure...
                     }
                 }.getOrElse {
                     throw it
@@ -279,6 +279,14 @@ public class MqttClient internal constructor(
     }
 
     // ---- Helper methods ---------------------------------------------------------------------------------------------
+
+    private fun clearSession() {
+        session.clear()
+
+        // The identifiers of incoming QoS 2 messages are session state as well: without clearing them, a new message
+        // of the next session reusing a remembered identifier would be swallowed as a duplicate.
+        publishReceivedPackets.clear()
+    }
 
     private fun createConnect(isCleanStart: Boolean): Connect {
         return Connect(

--- a/mqtt-client/src/commonTest/kotlin/de/kempmobil/ktor/mqtt/MqttClientTest.kt
+++ b/mqtt-client/src/commonTest/kotlin/de/kempmobil/ktor/mqtt/MqttClientTest.kt
@@ -9,6 +9,7 @@ import dev.mokkery.matcher.any
 import dev.mokkery.matcher.ofType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
+import kotlinx.io.bytestring.encodeToByteString
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -17,6 +18,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 
 @OptIn(ExperimentalTime::class)
@@ -424,7 +426,45 @@ class MqttClientTest {
         assertFalse(result.getOrThrow().source.isRetainMessage)  // 3. the actual message is not retained
     }
 
+    @Test
+    fun `a clean session does not treat new incoming QoS 2 packet ids as duplicates`() = runTest(timeout = 5.seconds) {
+        every { session.hasIncomingPacketId(any()) } returns false
+        every { session.rememberIncomingPacketId(any()) } returns true
+        everySuspend { engine.start() } returns Result.success(Unit)
+        everySuspend { engine.send(ofType<Connect>()) } calls {
+            packetResults.emit(Result.success(Connack(isSessionPresent = false, reason = Success)))
+            Result.success(Unit)
+        }
+        everySuspend { engine.send(ofType<Pubrec>()) } returns Result.success(Unit)
+        connectionState.emit(true)
+
+        val client = createClient(engine)
+
+        // An incoming QoS 2 message whose PUBREL never arrives, e.g. because the connection was lost
+        val first = async { client.publishedPackets.first() }
+        testScheduler.advanceUntilIdle()
+        packetResults.emit(Result.success(qos2Publish("before restart")))
+        assertEquals("before restart".encodeToByteString(), first.await().payload)
+
+        // After a clean start, the server may assign the same packet identifier to a brand-new message
+        assertTrue(client.connect(isCleanStart = true).isSuccess)
+
+        val second = async { client.publishedPackets.first() }
+        testScheduler.advanceUntilIdle()
+        packetResults.emit(Result.success(qos2Publish("after restart")))
+        assertEquals("after restart".encodeToByteString(), second.await().payload)
+    }
+
     // ---- Helper functions -------------------------------------------------------------------------------------------
+
+    private fun qos2Publish(payload: String): Publish {
+        return Publish(
+            qoS = QoS.EXACTLY_ONE,
+            packetIdentifier = 1u,
+            topic = "test/topic".toTopic(),
+            payload = payload.encodeToByteString()
+        )
+    }
 
     private fun createClient(connection: MqttEngine, id: String? = null): MqttClient {
         val config = buildConfig(DefaultEngineFactory("", 0)) {


### PR DESCRIPTION
The client remembers each incoming QoS 2 packet identifier (and its PUBREC) until the matching PUBREL arrives, so re-deliveries are not published twice. That memory is session state (MQTT 5 §4.1), but it survived `session.clear()`: after a clean start, or a reconnect answered with session present = 0, the server may assign a remembered identifier to a brand-new message, which the client then answers with the stale PUBREC and never publishes to the application — silent inbound message loss.

Both `session.clear()` call sites now go through a `clearSession()` that drops the PUBREC map alongside the session store.

The first commit adds a failing test that delivers a new QoS 2 message reusing a pre-clean-start packet identifier and expects it to reach the subscriber; the second commit makes it pass.
