### PR TITLE
Abort the QoS 2 handshake when the PUBREC carries an error reason

### DIFF
--- a/mqtt-client/src/commonMain/kotlin/de/kempmobil/ktor/mqtt/MqttClient.kt
+++ b/mqtt-client/src/commonMain/kotlin/de/kempmobil/ktor/mqtt/MqttClient.kt
@@ -375,10 +375,17 @@ public class MqttClient internal constructor(
         acquireSendQuotaSafe()
         val publish = inFlight.source
 
-        awaitResponseOf<Pubrec>({ it.isResponseFor<Pubrec>(publish) }) {
+        val pubrec = awaitResponseOf<Pubrec>({ it.isResponseFor<Pubrec>(publish) }) {
             engine.send(publish)
         }.getOrElse {
             it.throwHandshakeExceptionForTimeout("PUBREC", publish)
+        }
+
+        if (pubrec.reason >= UnspecifiedError) {
+            // The server rejected the message, hence the PUBREL must not be sent [MQTT-4.3.3-1] and the message
+            // must not be retransmitted on session resume either.
+            session.acknowledge(inFlight)
+            throw HandshakeFailedException("Received PUBREC with reason ${pubrec.reason} for $publish", publish)
         }
 
         val pubrel = session.replace(inFlight)

--- a/mqtt-client/src/commonTest/kotlin/de/kempmobil/ktor/mqtt/MqttClientTest.kt
+++ b/mqtt-client/src/commonTest/kotlin/de/kempmobil/ktor/mqtt/MqttClientTest.kt
@@ -7,6 +7,7 @@ import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.matcher.any
 import dev.mokkery.matcher.ofType
+import dev.mokkery.verify.VerifyMode
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -391,6 +392,32 @@ class MqttClientTest {
         verify { session.store(inFlightPublish.source) }
         verify { session.replace(inFlightPublish) }
         verify { session.acknowledge(inFlightPubrel) }
+    }
+
+    @Test
+    fun `publish a QoS 2 message aborts the handshake when the PUBREC carries an error`() = runTest {
+        val client = createClient(engine)
+        connectionState.emit(true)
+        everySuspend { engine.send(ofType<Publish>()) } calls {
+            packetResults.emit(Result.success(Pubrec(1u, UnspecifiedError)))
+            Result.success(Unit)
+        }
+        everySuspend { engine.send(ofType<Pubrel>()) } returns Result.success(Unit)
+        every { session.store(any()) } calls { (publish: Publish) ->
+            InFlightPublish(publish, Clock.System.now(), 1)
+        }
+        every { session.replace(any()) } calls { (inFlight: InFlightPublish) ->
+            InFlightPubrel(inFlight, 1.toLong())
+        }
+        every { session.acknowledge(any()) } returns Unit
+
+        val result = client.publish(PublishRequest("test/topic") {
+            desiredQoS = QoS.EXACTLY_ONE
+        })
+
+        assertTrue(result.isFailure, "A PUBREC with an error reason means the message was not delivered")
+        verifySuspend(VerifyMode.not) { engine.send(ofType<Pubrel>()) } // MQTT-4.3.3-1
+        verify { session.acknowledge(any()) } // The rejected message must not be retransmitted on session resume
     }
 
     @Test


### PR DESCRIPTION
A PUBREC of `0x80` or greater means the server rejected the message and discarded its state for the packet identifier, and the sender must not continue the handshake [MQTT-4.3.3-1]. The client ignored the PUBREC reason code: it sent a PUBREL the server answers with `Packet Identifier not found` at best, waited for a PUBCOMP — and because the in-flight PUBLISH also stayed in the session store, the rejected message was retransmitted on every session resume, rejected again, forever.

The handshake now aborts on an error PUBREC and the message is acknowledged out of the session store. The send quota permit is deliberately *not* released on this path: `handlePacket()` already releases it when the error PUBREC arrives (§4.9), so releasing here would double-count.

The first commit adds a failing test asserting no PUBREL follows an error PUBREC; the second makes it pass.
