### PR TITLE
Fix a reconnect being destroyed by the previous connection's late cleanup

### DIFF
--- a/mqtt-client/src/commonMain/kotlin/de/kempmobil/ktor/mqtt/DefaultEngine.kt
+++ b/mqtt-client/src/commonMain/kotlin/de/kempmobil/ktor/mqtt/DefaultEngine.kt
@@ -19,6 +19,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.io.EOFException
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
 
 /**
  * @property config the engine config
@@ -50,8 +53,16 @@ internal class DefaultEngine(
 
     private var receiverJob: Job? = null
 
+    // Incremented on every start(). Cleanup paths capture the epoch of the connection they belong
+    // to, so a cleanup that runs late -- after a reconnect has already replaced the engine state --
+    // recognizes it is stale and must not tear down the new connection's resources.
+    @OptIn(ExperimentalAtomicApi::class)
+    private val connectionEpoch = AtomicInt(0)
+
+    @OptIn(ExperimentalAtomicApi::class)
     override suspend fun start(): Result<Unit> {
         return try {
+            val epoch = connectionEpoch.incrementAndFetch()
             socket = scope.async {
                 val socket = withTimeout(config.connectionTimeout) {
                     socketHandler.openSocket(config)
@@ -64,7 +75,7 @@ internal class DefaultEngine(
                 // It's important to open the read channel here, if we do it in the job below exceptions will be ignored
                 val readChannel = socket.openReadChannel()
                 receiverJob = scope.launch {
-                    readChannel.incomingMessageLoop()
+                    readChannel.incomingMessageLoop(epoch)
                 }
             }
             Result.success(Unit)
@@ -73,17 +84,20 @@ internal class DefaultEngine(
         }
     }
 
+    @OptIn(ExperimentalAtomicApi::class)
     override suspend fun send(packet: Packet): Result<Unit> {
-        return sendChannel?.doSend(packet)
+        val epoch = connectionEpoch.load()
+        return sendChannel?.doSend(packet, epoch)
             ?: Result.failure(ConnectionException("Not connected to ${config.host}:${config.port}"))
     }
 
+    @OptIn(ExperimentalAtomicApi::class)
     override suspend fun disconnect() {
         socket?.let {
             socket = null
             it.close()
         }
-        disconnected()
+        disconnected(connectionEpoch.load())
     }
 
     override fun close() {
@@ -97,7 +111,7 @@ internal class DefaultEngine(
 
     // --- Private methods ---------------------------------------------------------------------------------------------
 
-    private suspend fun ByteReadChannel.incomingMessageLoop() {
+    private suspend fun ByteReadChannel.incomingMessageLoop(epoch: Int) {
         while (!isClosedForRead) {
             try {
                 _packetResults.emit(Result.success(readPacket()))
@@ -120,10 +134,10 @@ internal class DefaultEngine(
         }
 
         Logger.d { "Incoming message loop terminated" }
-        disconnected()
+        disconnected(epoch)
     }
 
-    private suspend fun ByteWriteChannel.doSend(packet: Packet): Result<Unit> {
+    private suspend fun ByteWriteChannel.doSend(packet: Packet, epoch: Int): Result<Unit> {
         Logger.d { "Sending $packet..." }
 
         return try {
@@ -134,20 +148,25 @@ internal class DefaultEngine(
             Result.success(Unit)
         } catch (ex: CancellationException) {
             Logger.v { "Packet writer job has been cancelled during write operation" }
-            disconnected()
+            disconnected(epoch)
             Result.failure(ex)
         } catch (ex: ClosedWriteChannelException) {
             Logger.w(throwable = ex) { "Write channel has been closed" }
-            disconnected()
+            disconnected(epoch)
             Result.failure(ex)
         } catch (ex: Exception) {
             Logger.w(throwable = ex) { "Write channel error detected" }
-            disconnected()
+            disconnected(epoch)
             Result.failure(ex)
         }
     }
 
-    private suspend fun disconnected() {
+    @OptIn(ExperimentalAtomicApi::class)
+    private suspend fun disconnected(epoch: Int) {
+        if (epoch != connectionEpoch.load()) {
+            Logger.v { "Skipping cleanup of connection $epoch, a newer connection owns the engine state" }
+            return
+        }
         _connected.value = false
         receiverJob?.cancel()
         socket?.close()

--- a/mqtt-client/src/jvmTest/kotlin/de/kempmobil/ktor/mqtt/DefaultEngineTest.kt
+++ b/mqtt-client/src/jvmTest/kotlin/de/kempmobil/ktor/mqtt/DefaultEngineTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.bytestring.encodeToByteString
 import java.nio.channels.ClosedChannelException
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -133,6 +134,41 @@ class DefaultEngineTest {
     }
 
     @Test
+    fun `a reconnect survives the late teardown of the previous connection`() = runTest(timeout = 60.seconds) {
+        // Tearing down a connection is asynchronous: the receiver loop notices its cancellation and
+        // cleans up on the engine's dispatcher. A reconnect that has already replaced the engine's
+        // socket, send channel and receiver job by then must not be torn down by that late cleanup.
+        // A single reconnect only fails when the cleanup loses the race, so cycle often enough that
+        // losing at least once is practically certain. Each accepted connection greets the client
+        // with a packet naming its cycle; when the receiver of a fresh connection was torn down, the
+        // greeting never surfaces in packetResults.
+        val cycles = 20
+        val greeting = { cycle: Int ->
+            Publish(topic = "test-topic".toTopic(), payload = "cycle-$cycle".encodeToByteString())
+        }
+        val acceptCount = AtomicInteger(0)
+        stopServerJob = startServer(accepts = cycles, writer = {
+            write(greeting(acceptCount.getAndIncrement()))
+        })
+
+        MqttEngine().use { engine ->
+            withContext(Dispatchers.Default) { // See runTest { } on why we need this
+                repeat(cycles) { cycle ->
+                    assertTrue(engine.start().isSuccess, "Reconnect $cycle failed to establish a connection")
+
+                    val expected = greeting(cycle)
+                    withTimeout(5.seconds) {
+                        engine.packetResults.first { it.getOrNull() == expected }
+                    }
+
+                    assertTrue(engine.connected.value, "Reconnect $cycle was torn down by the previous connection's cleanup")
+                    engine.disconnect()
+                }
+            }
+        }
+    }
+
+    @Test
     fun `when sending a packet it is received by server`() = runTest {
         val serverPackets = Channel<Packet>()
         stopServerJob = startServer(reader = {
@@ -225,25 +261,29 @@ class DefaultEngineTest {
     }
 
     /**
-     * Starts a socket server and returns an (unstarted) [Job] to stop it.
+     * Starts a socket server accepting [accepts] consecutive connections and returns an (unstarted)
+     * [Job] to stop it. The [reader] and [writer] callbacks are invoked once per accepted connection.
      */
     private suspend fun TestScope.startServer(
+        accepts: Int = 1,
         reader: (suspend ByteReadChannel.() -> Unit)? = null,
         writer: (suspend ByteWriteChannel.() -> Unit)? = null
     ): Job {
         val selectorManager = SelectorManager(Dispatchers.Default)
         val serverSocket = aSocket(selectorManager).tcp().bind(host, port)
-        var socket: Socket? = null
+        val sockets = mutableListOf<Socket>()
 
         backgroundScope.launch {
             try {
-                socket = serverSocket.accept().also { accepted ->
+                repeat(accepts) {
+                    val accepted = serverSocket.accept()
+                    sockets.add(accepted)
                     Logger.d { "Client connected successfully to $host:$port" }
                     if (reader != null) {
-                        accepted.openReadChannel().reader()
+                        launch { runCatching { accepted.openReadChannel().reader() } }
                     }
                     if (writer != null) {
-                        accepted.openWriteChannel(autoFlush = true).writer()
+                        launch { runCatching { accepted.openWriteChannel(autoFlush = true).writer() } }
                     }
                 }
             } catch (_: CancellationException) {
@@ -257,7 +297,7 @@ class DefaultEngineTest {
 
         // Don't use TestScope here, as this might get canceled after test execution!
         return CoroutineScope(Dispatchers.Default).launch(start = CoroutineStart.LAZY) {
-            socket?.close()
+            sockets.forEach { it.close() }
             serverSocket.close()
             selectorManager.close()
         }

--- a/mqtt-client/src/jvmTest/kotlin/de/kempmobil/ktor/mqtt/IntegrationTest.kt
+++ b/mqtt-client/src/jvmTest/kotlin/de/kempmobil/ktor/mqtt/IntegrationTest.kt
@@ -2,9 +2,7 @@ package de.kempmobil.ktor.mqtt
 
 import co.touchlab.kermit.Severity
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
@@ -17,6 +15,7 @@ import kotlin.random.Random
 import kotlin.random.nextUInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlin.time.Duration
@@ -91,29 +90,22 @@ class IntegrationTest {
 
     @Test
     fun `reconnect after disconnect returns proper connection states`() = runClientTest("reconnect") { client ->
-        val asserter = launch {
-            val states = client.connectionState.take(5)
-                .map {
-                    when (it) {
-                        is Connected -> 1
-                        is Disconnected -> 0
-                    }
-                }
-                .toList()
-            assertEquals(listOf(0, 1, 0, 1, 0), states, "Connection states don't match expected sequence")
-        }
+        // connectionState is backed by state flows: a collector always observes the current state, but a
+        // rapid transition can be conflated away before a concurrent collector is scheduled to see it. So
+        // await each expected state after each step instead of collecting the sequence concurrently.
+        assertIs<Disconnected>(client.connectionState.first(), "A new client must start out disconnected")
 
-        yield()
         client.assertConnected()
-        yield()
-        client.disconnect()
-        yield()
-        client.assertConnected()
-        yield()
-        client.disconnect()
-        yield()
+        client.connectionState.first { it is Connected }
 
-        asserter.join()
+        client.disconnect()
+        client.connectionState.first { it is Disconnected }
+
+        client.assertConnected()
+        client.connectionState.first { it is Connected }
+
+        client.disconnect()
+        client.connectionState.first { it is Disconnected }
     }
 
     @Test


### PR DESCRIPTION
The Build run for the #28 merge failed on main with `IntegrationTest > reconnect after disconnect returns proper connection states` dying after a minute with `UncompletedCoroutinesError` (https://github.com/ukemp/ktor-mqtt/actions/runs/30466624208), while #28's diff is an unrelated publish-builder default. Investigating that failure surfaced two problems — a racy test, and a real engine bug the racy test was hiding.

**The test:** it collected `connectionState.take(5)` concurrently with the connect/disconnect calls. `connectionState` is built from state flows, so a collector always sees the *current* state but is not guaranteed to observe every short-lived one; when a transition is conflated away, `take(5)` never completes and the test times out. The first commit rewrites it to await each expected state after each step — `first { }` on a state-backed flow terminates no matter how late the collector runs.

**The bug:** rewritten this way, the test fails deterministically when run alone (`./gradlew :mqtt-client:jvmTest --tests "de.kempmobil.ktor.mqtt.IntegrationTest.reconnect*"`): the second `connect()` times out waiting for its CONNACK. The engine's teardown is asynchronous — the receiver loop notices its cancellation on the engine dispatcher and then runs `disconnected()`, which unconditionally resets the connected flag, cancels the receiver job, and closes the socket and send channel. When a reconnect has already replaced those fields, the stale cleanup destroys the *new* connection. The test log shows it directly: the second CONNECT is sent, then "Packet reader job has been cancelled, terminating..." — the fresh reader killed by the previous connection's cleanup. Any reconnecting client can hit this in production whenever the old receiver loop is scheduled late.

The second commit adds an engine-level regression test: twenty connect/verify/disconnect cycles against a local socket server, where each accepted connection greets the client with a cycle-numbered packet. Pre-fix it reliably dies within the first few cycles ("Reconnect 2 was torn down by the previous connection's cleanup").

The third commit is the fix: every `start()` bumps a connection epoch, the cleanup paths carry the epoch of the connection they were created for, and `disconnected()` ignores calls from an epoch that no longer owns the engine state. Two *concurrent* `start()` calls still race each other for the engine fields — guarding `start()` itself is a larger change than this fix, and `MqttClient` never runs two connects concurrently.

Verified against a local Mosquitto container: the solo reconnect integration run went from 10/10 failures to 15 consecutive passes (24 of 25 overall; the one failure's report was lost to a subsequent run and did not reproduce), the 20-cycle engine test from failing within a few cycles to 10/10 green class runs (200 reconnect cycles), and the full `:mqtt-client:jvmTest` suite is green. iOS and JS targets compile.
